### PR TITLE
replaced `CanWrite` with `GetSetMethod != null`

### DIFF
--- a/01 Types/05_Vererbung.md
+++ b/01 Types/05_Vererbung.md
@@ -306,13 +306,22 @@ namespace InheritanceDemo.Application
         private static int _testCount = 0;
         private static int _testsSucceeded = 0;
 
+        private static bool HasWritableProperties(Type type) {
+            return type.GetProperties().Any(p => p.GetSetMethod() != null);
+        }
+
+        private static void TestWritableProperties(Type type) {
+            CheckAndWrite(() => !HasWritableProperties(type), $"Alle Properties in {type.Name} sind read only");
+        }
+
         private static void Main(string[] args)
         {
             Console.WriteLine("Teste Klassenimplementierung.");
-            CheckAndWrite(() => typeof(Product).GetProperties().Any() && typeof(Product).GetProperties().All(p => p.CanWrite == false), "Alle Properties in Product sind read only");
-            CheckAndWrite(() => typeof(Order).GetProperties().Any() && typeof(Order).GetProperties().All(p => p.CanWrite == false), "Alle Properties in Order sind read only");
-            CheckAndWrite(() => typeof(PaymentProvider).GetProperties().Any() && typeof(PaymentProvider).GetProperties().All(p => p.CanWrite == false), "Alle Properties in PaymentProvider sind read only");
-            CheckAndWrite(() => typeof(CreditCard).GetProperties().Any() && typeof(CreditCard).GetProperties().All(p => p.CanWrite == false), "Alle Properties in CreditCard sind read only");
+            TestWritableProperties(typeof(Product));
+            TestWritableProperties(typeof(Order));
+            TestWritableProperties(typeof(PaymentProvider));
+            TestWritableProperties(typeof(CreditCard));
+            TestWritableProperties(typeof(PrepaidCard));
 
             CheckAndWrite(() => typeof(PaymentProvider).GetConstructor(Type.EmptyTypes) is null, "Kein Defaultkonstruktor in PaymentProvider");
             CheckAndWrite(() => typeof(PaymentProvider).IsAbstract, "PaymentProvider ist abstrakt");


### PR DESCRIPTION
> `CanWrite` returns `true` if the property has a set accessor,
> even if the accessor is `private`, `internal` (or Friend in Visual Basic), or `protected`.  
> 
> [Source](https://learn.microsoft.com/en-us/dotnet/api/system.reflection.propertyinfo.canwrite?view=net-8.0)

This is a problem if someone were to write their Property like this:
```csharp
public decimal Limit {get; private set;}
```

`canWrite` will return true here even tho you can't actually write to it.

This PR only fixes a single occasion of this in `05_Vererbung` but a single `rg CanWrite` shows that this anti-pattern is used across the whole teaching material

```
PLF/Types - Plf3bhif20191113/Program.cs:            score += AssertTrue(() => info.CanWrite == false);
PLF/Types - Plf3bhif20191113/Program.cs:            score += AssertTrue(() => info2.CanWrite == false);
01 Types/03_Properties.md:            if (typeof(Teacher).GetProperty(nameof(Teacher.Firstname))?.CanWrite == false
01 Types/03_Properties.md:                && typeof(Teacher).GetProperty(nameof(Teacher.Lastname))?.CanWrite == false)
01 Types/03_Properties.md:            if (typeof(Teacher).GetProperty(nameof(Teacher.Longname))?.CanWrite == false
01 Types/03_Properties.md:            if (typeof(Teacher).GetProperty(nameof(Teacher.Shortname))?.CanWrite == false
01 Types/03_Properties.md:            if (typeof(Teacher).GetProperty(nameof(Teacher.IsSchoolEmail))?.CanWrite == false
01 Types/Uebungen/Blog/BlogManager.Application/TestHelpers.cs:            return type.GetProperties().All(p => p.CanWrite == false);
01 Types/Uebungen/LibraryManager/LibraryManager.Application/TestHelpers.cs:            return type.GetProperties().All(p => p.CanWrite == false);
01 Types/Uebungen/Anmeldesystem/RegistrationSystem.Application/TestHelpers.cs:            return type.GetProperties().All(p => p.CanWrite == false);
01 Types/Uebungen/Anmeldesystem/RegistrationSystem.Application/Program.cs:                () => typeof(RegistrationService).GetProperties().Any() && typeof(RegistrationService).GetProperties().All(p => p.CanWrite == false),
01 Types/Uebungen/Anmeldesystem/RegistrationSystem.Application/Program.cs:                () => typeof(Applicant).GetProperties().Any() && typeof(Applicant).GetProperties().All(p => p.CanWrite == false),
01 Types/Uebungen/Anmeldesystem/RegistrationSystem.Application/Program.cs:                () => typeof(AcceptedApplicant).GetProperties().Any() && typeof(AcceptedApplicant).GetProperties().All(p => p.CanWrite == false),
01 Types/Uebungen/Kalender/TeamCalendar.Application/TestHelpers.cs:            return type.GetProperties().All(p => p.CanWrite == false);
01 Types/Uebungen/HealthChecker/HealthChecker.Application/TestHelpers.cs:            return type.GetProperties().All(p => p.CanWrite == false);
01 Types/Uebungen/HealthChecker/HealthChecker.Application/Program.cs:                CheckAndWrite(() => typeof(Vaccination).GetProperty(nameof(Vaccination.FirstVaccination))?.CanWrite == false, "FirstVaccination is read-only.");
01 Types/Uebungen/CarRentalService/CarRentalService.Application/TestHelpers.cs:            type.GetProperty(propertyName)?.CanWrite == false;
01 Types/Uebungen/CarRentalService/CarRentalService.Application/TestHelpers.cs:            return type.GetProperties().All(p => p.CanWrite == false);
02 Linq/02_Filterung/LinqUebung1/LinqUebung1.Application/TestHelpers.cs:            return type.GetProperties().All(p => p.CanWrite == false);
```

In my commit I also added a method to make the code more [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself).
I don't really get why this isn't done in all tests because those should follow good practices in case students were to learn from them.